### PR TITLE
Ref #18 - Add incremental annotation processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
         kotlin_version = '1.3.61'
         kotlinxMetadataVersion = '0.0.5'
         kotlinBuilderAnnotationVersion = '1.0-SNAPSHOT'
-        autoServiceVersion = '1.0-rc4'
-        mapstructVersion = '1.3.1.Final'
+        autoServiceVersion = '1.0-rc7'
+        mapstructVersion = '1.4.0.Beta1'
         javaPoetVersion = '1.11.1'
     }
 

--- a/mapstruct-kotlin-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/mapstruct-kotlin-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,2 @@
+com.github.pozo.BuilderProcessor,isolating
+


### PR DESCRIPTION
Related to #18

This adds [incremental annotation processing](https://docs.gradle.org/5.0/userguide/java_plugin.html#sec:incremental_annotation_processing) for faster gradle builds.

By adding _src/main/resources/META-INF/gradle/incremental.annotation.processors_, it tells Gradle that the `com.github.pozo.BuilderProcessor` is an incremental processor.

A bump to MapStruct 1.4.0.Beta1 (https://github.com/mapstruct/mapstruct/pull/1971) and AutoService 1.0-rc.7 (https://github.com/google/auto/issues/615) is required.