### PR TITLE
Adding originatingElement to generated JavaBuild

### DIFF
--- a/mapstruct-kotlin-processor/src/main/kotlin/com/github/pozo/BuilderProcessor.kt
+++ b/mapstruct-kotlin-processor/src/main/kotlin/com/github/pozo/BuilderProcessor.kt
@@ -73,6 +73,7 @@ class BuilderProcessor : AbstractProcessor() {
         val packageName = processingEnv.elementUtils.getPackageOf(typeElement).toString()
         val builderClassName = "${typeElement.simpleName}Builder"
         val classBuilder = TypeSpec.classBuilder(builderClassName)
+            .addOriginatingElement(typeElement)
 
         with(classBuilder) {
             this.addModifiers(Modifier.PUBLIC, Modifier.FINAL)


### PR DESCRIPTION
MapStruct 1.4.0.Final was released recently, so I was hoping to take advantage of the full benefits of Kapt annotation incremental compiling for faster builds, but it didn't seem to be working and always seemed to do a full build.

The Builder annotation processing via mapstruct-kotlin had this spurious line in the logs during the build,
> [WARN] Issue detected with com.github.pozo.BuilderProcessor. Expected 1 originating source file when generating /project/build/generated/source/kapt/main/com/project/ItemBuilder.java, but detected 0: [].

I tracked down the error message to Jetbrains kapt, https://github.com/JetBrains/kotlin/blob/master/plugins/kapt3/kapt3-base/src/org/jetbrains/kotlin/kapt3/base/incremental/incrementalProcessors.kt#L126-L129.  Interestingly, if you hit this, it seems to set that `isFullRebuild = true`, which is probably not ideal.

Adding the `originatingElement` data class to the `TypeSpec.classBuilder` seems to correct the issue.